### PR TITLE
Add GitHub Action job to automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Commit ID to tag and create a release for'
+        required: true
+      version_number:
+        description: 'Release Version (Eg, 202012.00-LTS)'
+        required: true
+
+jobs:
+  tag-commit:
+    name: Tag commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+      - name: Configure git identity
+        run: |
+            git config --global user.name "Release Workflow"
+      - name: Tag Commit and Push to remote
+        run: |
+          git tag ${{ github.event.inputs.version_number }} -a -m "Release ${{ github.event.inputs.version_number }}"
+          git push origin --tags
+      - name: Verify tag on remote
+        run: |
+          git tag -d ${{ github.event.inputs.version_number }}
+          git remote update
+          git checkout tags/${{ github.event.inputs.version_number }}
+          git diff ${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+  create-zip:
+    needs: tag-commit
+    name: Create ZIP and verify package for release asset.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install ZIP tools
+        run: sudo apt-get install zip unzip
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.commit_id }}
+          path: FreeRTOS-LTS
+          submodules: recursive
+      - name: Checkout disabled submodules
+        run: |
+          cd FreeRTOS-LTS
+          git submodule update --init --checkout --recursive
+      - name: Create ZIP
+        run: |
+          zip -r FreeRTOS-LTS-${{ github.event.inputs.version_number }}.zip FreeRTOS-LTS -x "*.git*"
+          ls ./
+      - name: Validate created ZIP
+        run: |
+          mkdir zip-check
+          mv FreeRTOS-LTS-${{ github.event.inputs.version_number }}.zip zip-check
+          cd zip-check
+          unzip FreeRTOS-LTS-${{ github.event.inputs.version_number }}.zip -d FreeRTOS-LTS-${{ github.event.inputs.version_number }}
+          ls FreeRTOS-LTS-${{ github.event.inputs.version_number }}
+          diff -r -x "*.git*" FreeRTOS-LTS-${{ github.event.inputs.version_number }}/FreeRTOS-LTS/ ../FreeRTOS-LTS/
+  create-release:
+    needs: create-zip
+    name: Create Release and Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version_number }}
+          release_name: ${{ github.event.inputs.version_number }}
+          body: ${{ github.event.inputs.version_number }} Release
+          draft: false
+          prerelease: false
+      - name: Download ZIP artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: FreeRTOS-LTS-${{ github.event.inputs.version_number }}.zip
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./FreeRTOS-LTS-${{ github.event.inputs.version_number }}.zip
+          asset_name: FreeRTOS-LTS-${{ github.event.inputs.version_number }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       commit_id:
-        description: 'Commit ID to tag and create a release for'
+        description: 'Commit ID/branch to tag and create a release for'
         required: true
       version_number:
         description: 'Release Version (Eg, 202012.00-LTS)'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,11 @@ jobs:
           unzip FreeRTOS-LTS-${{ github.event.inputs.version_number }}.zip -d FreeRTOS-LTS-${{ github.event.inputs.version_number }}
           ls FreeRTOS-LTS-${{ github.event.inputs.version_number }}
           diff -r -x "*.git*" FreeRTOS-LTS-${{ github.event.inputs.version_number }}/FreeRTOS-LTS/ ../FreeRTOS-LTS/
+      - name: Create artifact of ZIP
+        uses: actions/upload-artifact@v2
+        with:
+          name: FreeRTOS-LTS-${{ github.event.inputs.version_number }}.zip
+          path: zip-check/FreeRTOS-LTS-${{ github.event.inputs.version_number }}.zip
   create-release:
     needs: create-zip
     name: Create Release and Upload Release Asset


### PR DESCRIPTION
**Add a GitHub Action job to trigger a release process** which includes operations of: 
1. Creating and pushing the release tag to the repository 
2. Verifying the pushed tag (performing a diff with the commit ID which is tagged) 
3. Creating a ZIP for the release asset. 
4. Verifying the ZIP by performing a diff check and running unit tests on the unzipped files. 5. Creating a release on the repository for the tag, and uploading the ZIP as the release asset

The workflow can be manually triggered and takes the input values of **Commit ID** (to create a release for) and the **Version string** for tagging the release with

**Testing**
Here is an example run of the release job on my fork repository: 
https://github.com/aggarw13/FreeRTOS-LTS/actions/runs/600604996
It pushed the test tag (`202012.01-LTS`) and created a release along with the release asset on the repository: https://github.com/aggarw13/FreeRTOS-LTS/releases/tag/202012.01-LTS