### PR TITLE
Move migration guide from webpage to github

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,4 +15,4 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](LICENSE.md) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Libraries in this GitHub branch (also listed below) are part of the [FreeRTOS 20
 
 ## Upgrading to FreeRTOS 202210-LTS from a previous version of FreeRTOS LTS
 
-Refer to https://freertos.org/lts-libraries.html on how to upgrade to FreeRTOS 202210 LTS
+FreeRTOS 202210 LTS libraries are backward compatible with 202012.xx LTS, except
+for the coreMQTT and FreeRTOS-Plus-TCP libraries. For FreeRTOS-Plus-TCP, refer to
+[these instructions](https://github.com/freertos/freertos-plus-tcp#upgrading-to-v300-and-above)
+on how to update your projects to use the new version. For coreMQTT, refer to
+[these instructions](https://github.com/FreeRTOS/coreMQTT/blob/main/MigrationGuide.md).
 
 ## FreeRTOS LTS Versioning and Patches
 


### PR DESCRIPTION

**Description of changes:**

Move migration guide from webpage to github

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
