### PR TITLE
Update upload-artifact version to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit_id }}
       - name: Configure git identity
@@ -43,7 +43,7 @@ jobs:
       - name: Install ZIP tools
         run: sudo apt-get install zip unzip
       - name: Checkout code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit_id }}
           path: FreeRTOS-LTS
@@ -65,7 +65,7 @@ jobs:
           ls FreeRTOSv${{ github.event.inputs.version_number }}
           diff -r -x "*.git*" FreeRTOSv${{ github.event.inputs.version_number }}/FreeRTOS-LTS/ ../FreeRTOS-LTS/
       - name: Create artifact of ZIP
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v2
         with:
           name: FreeRTOSv${{ github.event.inputs.version_number }}.zip
           path: zip-check/FreeRTOSv${{ github.event.inputs.version_number }}.zip


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Compare the log. It looks like extra zip is added in v4 github action. Revert it back to v2 for compatible with our release.yml file.
Success example : https://github.com/FreeRTOS/coreMQTT/actions/runs/9414959495/job/25934929029
```
Run actions/upload-artifact@v2
With the provided path, there will be 1 file uploaded
Starting artifact upload
For more detailed logs during the artifact upload process, enable step-debugging: https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging
Artifact name is valid!
Container for artifact "coreMQTT-v2.3.0.zip" successfully created. Starting upload of file(s)
Total size of all the files uploaded is 1908864 bytes
File upload process has finished. Finalizing the artifact upload
Artifact has been finalized. All files have been successfully uploaded!

The raw size of all the files that were specified for upload is 1908864 bytes
The size of all the files that were uploaded is 1908864 bytes. This takes into account any gzip compression used to reduce the upload size, time and storage

Note: The size of downloaded zips can differ significantly from the reported size. For more information see: https://github.com/actions/upload-artifact#zipped-artifact-downloads 

Artifact coreMQTT-v2.3.0.zip has been successfully uploaded!
```

Failed in the action : https://github.com/FreeRTOS/FreeRTOS-LTS/actions/runs/9692564847/job/26746156173
The log is observed "**Artifact FreeRTOSv202406.00-LTS.zip.zip** successfully finalized. Artifact ID 1643542101".
```
Run actions/upload-artifact@v4
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
Beginning upload of artifact content to blob storage
Uploaded bytes 8388608
Uploaded bytes 16777216
Uploaded bytes 21671174
Finished uploading artifact content to blob storage!
SHA256 hash of uploaded artifact zip is 8d0f83de1d8e05a13088226bb83880be5bcf9a83165d4983f1edcfffba1cb260
Finalizing artifact upload
Artifact FreeRTOSv202406.00-LTS.zip.zip successfully finalized. Artifact ID 1643542101
Artifact FreeRTOSv202406.00-LTS.zip has been successfully uploaded! Final size is 21671174 bytes. Artifact ID is 1643542101
Artifact download URL: https://github.com/FreeRTOS/FreeRTOS-LTS/actions/runs/9692564847/artifacts/1643542101

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
