### PR TITLE
Update FreeRTOS-Plus-TCP to v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Long Term Support (LTS) release of the following libraries:
 * [FreeRTOS-Kernel V11.1.0](https://github.com/FreeRTOS/FreeRTOS-Kernel/tree/V11.1.0)
-* [FreeRTOS-Plus-TCP V4.2.0](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.0)
+* [FreeRTOS-Plus-TCP V4.2.1](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.1)
 * [coreMQTT v2.3.0](https://github.com/FreeRTOS/coreMQTT/tree/v2.3.0)
 * [coreHTTP v3.1.1](https://github.com/FreeRTOS/coreHTTP/tree/v3.1.1)
 * [corePKCS11 v3.6.1](https://github.com/FreeRTOS/corePKCS11/tree/v3.6.1)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Libraries in this GitHub branch (also listed below) are part of the FreeRTOS 202
 | Library                     | Version             | LTS Until  | LTS Repo URL                                                                    |
 |-------------------------    |---------------------|------------|-------------------------------------------------------------------------------  |
 | FreeRTOS Kernel             | 11.1.0              | 06/30/2026 | https://github.com/FreeRTOS/FreeRTOS-Kernel/tree/V11.1.0                        |
-| FreeRTOS-Plus-TCP           | 4.2.0               | 06/30/2026 | https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.0                       |
+| FreeRTOS-Plus-TCP           | 4.2.1               | 06/30/2026 | https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.1                       |
 | coreMQTT                    | 2.3.0               | 06/30/2026 | https://github.com/FreeRTOS/coreMQTT/tree/v2.3.0                                |
 | coreHTTP                    | 3.1.1               | 06/30/2026 | https://github.com/FreeRTOS/coreHTTP/tree/v3.1.1                                |
 | corePKCS11                  | 3.6.1               | 06/30/2026 | https://github.com/FreeRTOS/corePKCS11/tree/v3.6.1                              |

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,7 +10,7 @@ dependencies:
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"
       path: "FreeRTOS/FreeRTOS-Kernel"
   - name: "FreeRTOS-Plus-TCP"
-    version: "V4.2.0"
+    version: "V4.2.1"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Plus-TCP.git"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update FreeRTOS-Plus-TCP to v4.2.1 for version tag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
