### PR TITLE
 Follow Security Guide to update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           ls FreeRTOSv"$VERSION_NUMBER"
           diff -r -x "*.git*" FreeRTOSv"$VERSION_NUMBER"/FreeRTOS-LTS/ ../FreeRTOS-LTS/
       - name: Create artifact of ZIP
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: FreeRTOSv${{ github.event.inputs.version_number }}.zip
           path: zip-check/FreeRTOSv${{ github.event.inputs.version_number }}.zip
@@ -100,7 +100,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Download ZIP artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: FreeRTOSv${{ github.event.inputs.version_number }}.zip
       - name: Upload Release Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,21 +20,31 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit_id }}
       - name: Configure git identity
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
-            git config --global user.name ${{ github.actor }}
-            git config --global user.email ${{ github.actor }}@users.noreply.github.com
+            git config --global user.name "$ACTOR"
+            git config --global user.email "$ACTOR"@users.noreply.github.com
       - name: create a new branch that references commit id
-        run: git checkout -b ${{ github.event.inputs.version_number }} ${{ github.event.inputs.commit_id }}
+        env:
+          VERSION_NUMBER: ${{ github.event.inputs.version_number }}
+          COMMIT_ID: ${{ github.event.inputs.commit_id }}
+        run: git checkout -b "$VERSION_NUMBER" "$COMMIT_ID"
       - name: Tag Commit and Push to remote
+        env:
+          VERSION_NUMBER: ${{ github.event.inputs.version_number }}
         run: |
-          git tag ${{ github.event.inputs.version_number }} -a -m "Release ${{ github.event.inputs.version_number }}"
+          git tag "$VERSION_NUMBER" -a -m "Release $VERSION_NUMBER"
           git push origin --tags
       - name: Verify tag on remote
+        env:
+          VERSION_NUMBER: ${{ github.event.inputs.version_number }}
+          COMMIT_ID: ${{ github.event.inputs.commit_id }}
         run: |
-          git tag -d ${{ github.event.inputs.version_number }}
+          git tag -d "$VERSION_NUMBER"
           git remote update
-          git checkout tags/${{ github.event.inputs.version_number }}
-          git diff ${{ github.event.inputs.commit_id }} tags/${{ github.event.inputs.version_number }}
+          git checkout tags/"$VERSION_NUMBER"
+          git diff "$COMMIT_ID" tags/"$VERSION_NUMBER"
   create-zip:
     needs: tag-commit
     name: Create ZIP and verify package for release asset.
@@ -53,17 +63,21 @@ jobs:
           cd FreeRTOS-LTS
           git submodule update --init --checkout --recursive
       - name: Create ZIP
+        env:
+          VERSION_NUMBER: ${{ github.event.inputs.version_number }}
         run: |
-          zip -r FreeRTOSv${{ github.event.inputs.version_number }}.zip FreeRTOS-LTS -x "*.git*"
+          zip -r FreeRTOSv"$VERSION_NUMBER".zip FreeRTOS-LTS -x "*.git*"
           ls ./
       - name: Validate created ZIP
+        env:
+          VERSION_NUMBER: ${{ github.event.inputs.version_number }}
         run: |
           mkdir zip-check
-          mv FreeRTOSv${{ github.event.inputs.version_number }}.zip zip-check
+          mv FreeRTOSv"$VERSION_NUMBER".zip zip-check
           cd zip-check
-          unzip FreeRTOSv${{ github.event.inputs.version_number }}.zip -d FreeRTOSv${{ github.event.inputs.version_number }}
-          ls FreeRTOSv${{ github.event.inputs.version_number }}
-          diff -r -x "*.git*" FreeRTOSv${{ github.event.inputs.version_number }}/FreeRTOS-LTS/ ../FreeRTOS-LTS/
+          unzip FreeRTOSv"$VERSION_NUMBER".zip -d FreeRTOSv"$VERSION_NUMBER"
+          ls FreeRTOSv"$VERSION_NUMBER"
+          diff -r -x "*.git*" FreeRTOSv"$VERSION_NUMBER"/FreeRTOS-LTS/ ../FreeRTOS-LTS/
       - name: Create artifact of ZIP
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Follow [Security Guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) to update release.yml.
- Update upload-artifact/download-artifact to v4 because v2 is now deprecated.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Execute release flow in local branch, see result by https://github.com/ActoryOu/FreeRTOS-LTS/actions/runs/11627278404.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
