### PR TITLE
202406.03-LTS Patch Release Update 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog for FreeRTOS 202406-LTS
 
+## 202406.03-LTS (June 2025)
+
+Update the following libraries in the Long Term Support (LTS) patch release:
+* [FreeRTOS-Plus-TCP V4.2.4](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.4)
+
 ## 202406.02-LTS (June 2025)
 
 Update the following libraries in the Long Term Support (LTS) patch release:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Libraries in this GitHub branch (also listed below) are part of the FreeRTOS 202
 | Library                     | Version             | LTS Until  | LTS Repo URL                                                                    |
 |-------------------------    |---------------------|------------|-------------------------------------------------------------------------------  |
 | FreeRTOS Kernel             | 11.1.0              | 06/30/2026 | https://github.com/FreeRTOS/FreeRTOS-Kernel/tree/V11.1.0                        |
-| FreeRTOS-Plus-TCP           | 4.2.3               | 06/30/2026 | https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.3                       |
+| FreeRTOS-Plus-TCP           | 4.2.4               | 06/30/2026 | https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.4                       |
 | coreMQTT                    | 2.3.1               | 06/30/2026 | https://github.com/FreeRTOS/coreMQTT/tree/v2.3.1                                |
 | coreHTTP                    | 3.1.1               | 06/30/2026 | https://github.com/FreeRTOS/coreHTTP/tree/v3.1.1                                |
 | corePKCS11                  | 3.6.3               | 06/30/2026 | https://github.com/FreeRTOS/corePKCS11/tree/v3.6.3                              |

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,7 +10,7 @@ dependencies:
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"
       path: "FreeRTOS/FreeRTOS-Kernel"
   - name: "FreeRTOS-Plus-TCP"
-    version: "V4.2.3"
+    version: "V4.2.4"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Plus-TCP.git"


### PR DESCRIPTION
## Description of changes:
This PR updates the following libraries for the 202406.02-LTS patch release:
|Library                          | Version |
|----------------------|---------|
| FreeRTOS-Plus-TCP  | V4.2.4    |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
