### PR TITLE
Update FreeRTOS-Plus-TCP submodule pointer to latest LTS version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
         description: 'Release Version (Eg, 202012.00-LTS)'
         required: true
 
+# Workflow permissions block
+permissions:
+  contents: write # This grants write access to repository content, including pushing commits/tags and creating releases.
+
 jobs:
   tag-commit:
     name: Tag commit
@@ -85,6 +89,7 @@ jobs:
           path: zip-check/FreeRTOSv${{ github.event.inputs.version_number }}.zip
   create-release:
     permissions:
+      contents: write
       id-token: write
     needs: create-zip
     name: Create Release and Upload Release Asset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog for FreeRTOS 202406-LTS
 
+## 202406.04-LTS (October 2025)
+
+Update the following libraries in the Long Term Support (LTS) patch release:
+* [FreeRTOS-Plus-TCP V4.2.5](https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.5)
+
 ## 202406.03-LTS (June 2025)
 
 Update the following libraries in the Long Term Support (LTS) patch release:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Libraries in this GitHub branch (also listed below) are part of the FreeRTOS 202
 | Library                     | Version             | LTS Until  | LTS Repo URL                                                                    |
 |-------------------------    |---------------------|------------|-------------------------------------------------------------------------------  |
 | FreeRTOS Kernel             | 11.1.0              | 06/30/2026 | https://github.com/FreeRTOS/FreeRTOS-Kernel/tree/V11.1.0                        |
-| FreeRTOS-Plus-TCP           | 4.2.4               | 06/30/2026 | https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.4                       |
+| FreeRTOS-Plus-TCP           | 4.2.5               | 06/30/2026 | https://github.com/FreeRTOS/FreeRTOS-Plus-TCP/tree/V4.2.5                       |
 | coreMQTT                    | 2.3.1               | 06/30/2026 | https://github.com/FreeRTOS/coreMQTT/tree/v2.3.1                                |
 | coreHTTP                    | 3.1.1               | 06/30/2026 | https://github.com/FreeRTOS/coreHTTP/tree/v3.1.1                                |
 | corePKCS11                  | 3.6.3               | 06/30/2026 | https://github.com/FreeRTOS/corePKCS11/tree/v3.6.3                              |

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,7 +10,7 @@ dependencies:
       url: "https://github.com/FreeRTOS/FreeRTOS-Kernel.git"
       path: "FreeRTOS/FreeRTOS-Kernel"
   - name: "FreeRTOS-Plus-TCP"
-    version: "V4.2.4"
+    version: "V4.2.5"
     repository:
       type: "git"
       url: "https://github.com/FreeRTOS/FreeRTOS-Plus-TCP.git"


### PR DESCRIPTION
## Description of changes:
This PR updates the following libraries for the 202406.02-LTS patch release:
|Library                          | Version |
|----------------------|---------|
| FreeRTOS-Plus-TCP  | V4.2.5    |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
